### PR TITLE
Add light/dark mode toggle with D3 visualization improvements

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,50 +1,56 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { useRouter } from "next/router";
 import Link from "next/link";
 
 const data = require("../data/content.json");
 
-const Header = (props) => {
+const NODE_VARS = {
+  development: "var(--node-development)",
+  graphics: "var(--node-graphics)",
+  app: "var(--node-app)",
+  docs: "var(--node-docs)",
+  data: "var(--node-data)",
+  reporting: "var(--node-reporting)",
+};
+
+const getColor = (type) => NODE_VARS[type] ?? "var(--node-default)";
+
+const NAV_LINKS = [
+  { href: "/", label: "Home", key: "home" },
+  { href: "/projects", label: "Projects", key: "projects" },
+  { href: "/resume", label: "Resume", key: "resume" },
+  { href: "/contact", label: "Contact", key: "contact" },
+];
+
+const Header = () => {
   const router = useRouter();
-  const page = router.route.replaceAll("/", "");
-  const [activeLink, setActiveLink] = useState(page === "" ? "home" : page);
-
-  useEffect(() => {
-    if (activeLink.includes("blog")) {
-      setActiveLink("blog");
-    }
-  }, [activeLink, router]);
-
-  useEffect(() => {
-    setActiveLink(page === "" ? "home" : page);
-  }, [page, router]);
-
   const svgRef = useRef(null);
+
+  const page = router.route.replace(/\//g, "");
+  const activeLink =
+    page === "" ? "home" : page.startsWith("blog") ? "blog" : page;
 
   useEffect(() => {
     let simulation;
+
     (async () => {
       const d3 = await import("d3");
 
-      const vizEl = document.getElementById("viz");
-      const width = vizEl ? vizEl.offsetWidth : 0;
+      const width = svgRef.current?.parentElement?.offsetWidth ?? 0;
       const height = 150;
-      const strength = 0.09;
 
-      const nodes = data.stories.map((d) => ({
-        radius: d.storyType.split(" ").length * 3 + 4,
-        type: d.storyType.split(" "),
-      }));
-
-      // Initialize positions to avoid sweeping from the origin.
-      nodes.forEach((n) => {
-        n.x = Math.random() * width;
-        n.y = Math.random() * height;
+      const nodes = data.stories.map((d) => {
+        const type = d.storyType.split(" ");
+        return {
+          radius: type.length * 3 + 4,
+          type,
+          x: Math.random() * width,
+          y: Math.random() * height,
+        };
       });
 
       const root = nodes[0];
       root.radius = 0;
-      // Start root at the center and fix it initially.
       root.fx = width / 2;
       root.fy = height / 2;
 
@@ -54,63 +60,8 @@ const Header = (props) => {
         .style("width", "100%")
         .style("height", `${height}px`);
 
-      function getColor(t) {
-        if (t === "development") {
-          // Brick red (serious, not warning-red)
-          return "#8b80d6";
-        } else if (t === "graphics") {
-          // Gold / ochre (visual, warm)
-          return "#d4a44c";
-        } else if (t === "app") {
-          // True green (runtime, alive)
-          return "#4fa36f";
-        } else if (t === "docs") {
-          // Burnt amber (text, paper)
-          return "#b8894a";
-        } else if (t === "data") {
-          // Olive-lime (analytical, unmistakable)
-          return "#9cab3c";
-        } else if (t === "reporting") {
-          // Your coder purple (unchanged)
-          return "#c65a4a";
-        } else {
-          return "#ff79c6";
-        }
-      }
-
-      function ticked() {
-        svg
-          .selectAll("circle.node")
-          .attr("cx", (d) => d.x)
-          .attr("cy", (d) => d.y);
-        svg
-          .selectAll("circle.node-blur")
-          .attr("cx", (d) => d.x)
-          .attr("cy", (d) => d.y);
-      }
-
-      simulation = d3
-        .forceSimulation(nodes)
-        .force(
-          "charge",
-          d3.forceManyBody().strength((d, i) => (i ? 0 : -250)),
-        )
-        .force("x", d3.forceX(width / 2).strength(strength))
-        .force("y", d3.forceY(height / 2).strength(strength))
-        .force(
-          "collision",
-          d3.forceCollide().radius((d) => d.radius),
-        )
-        .on("tick", ticked);
-
-      svg
-        .selectAll("circle.node")
-        .data(nodes.slice(1))
-        .join("circle")
-        .attr("class", "node")
-        .attr("r", (d) => d.radius)
-        .attr("opacity", 0.7)
-        .attr("fill", (d, i) => getColor(d.type[0]));
+      // Clear previous renders (guards against React StrictMode double-invoke)
+      svg.selectAll("*").remove();
 
       const defs = svg.append("defs");
 
@@ -128,29 +79,29 @@ const Header = (props) => {
         .attr("cy", height / 2)
         .attr("r", 17);
 
+      const visibleNodes = nodes.slice(1);
+
+      svg
+        .selectAll("circle.node")
+        .data(visibleNodes)
+        .join("circle")
+        .attr("class", "node")
+        .attr("r", (d) => d.radius)
+        .attr("fill", (d) => getColor(d.type[0]));
+
       svg
         .append("g")
         .attr("clip-path", "url(#btn-clip)")
         .attr("filter", "url(#btn-blur)")
         .selectAll("circle.node-blur")
-        .data(nodes.slice(1))
+        .data(visibleNodes)
         .join("circle")
         .attr("class", "node-blur")
         .attr("r", (d) => d.radius)
-        .attr("opacity", 1)
         .attr("fill", (d) => getColor(d.type[0]));
 
       const isDark = () => document.documentElement.dataset.theme === "dark";
       const themeIcon = () => (isDark() ? "☀️" : "🌘");
-
-      const toggleTheme = () => {
-        document.documentElement.dataset.theme = isDark() ? "light" : "dark";
-        btn.select("text").text(themeIcon());
-        btn.attr(
-          "aria-label",
-          isDark() ? "Switch to light mode" : "Switch to dark mode",
-        );
-      };
 
       const btn = svg
         .append("g")
@@ -162,14 +113,23 @@ const Header = (props) => {
         .attr(
           "aria-label",
           isDark() ? "Switch to light mode" : "Switch to dark mode",
-        )
-        .on("click", toggleTheme)
-        .on("keydown", (event) => {
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            toggleTheme();
-          }
-        });
+        );
+
+      function toggleTheme() {
+        document.documentElement.dataset.theme = isDark() ? "light" : "dark";
+        btn.select("text").text(themeIcon());
+        btn.attr(
+          "aria-label",
+          isDark() ? "Switch to light mode" : "Switch to dark mode",
+        );
+      }
+
+      btn.on("click", toggleTheme).on("keydown", (event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          toggleTheme();
+        }
+      });
 
       btn
         .append("circle")
@@ -186,65 +146,58 @@ const Header = (props) => {
         .attr("pointer-events", "none")
         .text(themeIcon());
 
-      svg.on("mousemove", function (event) {
-        const p1 = d3.pointer(event, this);
-        root.fx = p1[0];
-        root.fy = p1[1];
+      simulation = d3
+        .forceSimulation(nodes)
+        .force(
+          "charge",
+          d3.forceManyBody().strength((_, i) => (i ? 0 : -250)),
+        )
+        .force("x", d3.forceX(width / 2).strength(0.09))
+        .force("y", d3.forceY(height / 2).strength(0.09))
+        .force(
+          "collision",
+          d3.forceCollide().radius((d) => d.radius),
+        )
+        .on("tick", () => {
+          svg
+            .selectAll("circle.node, circle.node-blur")
+            .attr("cx", (d) => d.x)
+            .attr("cy", (d) => d.y);
+        });
 
-        simulation.alpha(0.3).restart();
-      });
+      svg
+        .on("mousemove", function (event) {
+          const [x, y] = d3.pointer(event, this);
+          root.fx = x;
+          root.fy = y;
+          simulation.alpha(0.3).restart();
+        })
+        .on("mouseleave", () => {
+          root.fx = width / 2;
+          root.fy = height / 2;
+          simulation.alpha(0.3).restart();
+        });
     })();
 
-    return () => {
-      if (simulation) simulation.stop();
-    };
+    return () => simulation?.stop();
   }, []);
 
   return (
     <header>
       <div id="viz">
-        <svg ref={svgRef}></svg>
+        <svg ref={svgRef} />
       </div>
 
       <nav role="navigation">
         <ul>
-          <li id="nav-home" className={activeLink === "home" ? "active" : ""}>
-            <Link href="/" onClick={() => setActiveLink("home")}>
-              Home
-            </Link>
-          </li>
-          <li
-            id="nav-experience"
-            className={activeLink === "projects" ? "active" : ""}
-          >
-            <Link href="/projects" onClick={() => setActiveLink("projects")}>
-              Projects
-            </Link>
-          </li>
-          <li
-            id="nav-resume"
-            className={activeLink === "resume" ? "active" : ""}
-          >
-            <Link href="/resume" onClick={() => setActiveLink("resume")}>
-              Resume
-            </Link>
-          </li>
-          <li
-            id="nav-contact"
-            className={activeLink === "contact" ? "active" : ""}
-          >
-            <Link href="/contact" onClick={() => setActiveLink("contact")}>
-              Contact
-            </Link>
-          </li>
-          {activeLink.includes("blog") && (
-            <li
-              id="nav-blog"
-              className={activeLink.includes("blog") ? "active" : ""}
-            >
-              <Link href="/blog" onClick={() => setActiveLink("blog")}>
-                Blog
-              </Link>
+          {NAV_LINKS.map(({ href, label, key }) => (
+            <li key={key} className={activeLink === key ? "active" : ""}>
+              <Link href={href}>{label}</Link>
+            </li>
+          ))}
+          {activeLink === "blog" && (
+            <li className="active">
+              <Link href="/blog">Blog</Link>
             </li>
           )}
         </ul>

--- a/components/Header.js
+++ b/components/Header.js
@@ -80,7 +80,11 @@ const Header = (props) => {
 
       function ticked() {
         svg
-          .selectAll("circle")
+          .selectAll("circle.node")
+          .attr("cx", (d) => d.x)
+          .attr("cy", (d) => d.y);
+        svg
+          .selectAll("circle.node-blur")
           .attr("cx", (d) => d.x)
           .attr("cy", (d) => d.y);
       }
@@ -100,12 +104,87 @@ const Header = (props) => {
         .on("tick", ticked);
 
       svg
-        .selectAll("circle")
+        .selectAll("circle.node")
         .data(nodes.slice(1))
         .join("circle")
+        .attr("class", "node")
         .attr("r", (d) => d.radius)
         .attr("opacity", 0.7)
         .attr("fill", (d, i) => getColor(d.type[0]));
+
+      const defs = svg.append("defs");
+
+      defs
+        .append("filter")
+        .attr("id", "btn-blur")
+        .append("feGaussianBlur")
+        .attr("stdDeviation", 3);
+
+      defs
+        .append("clipPath")
+        .attr("id", "btn-clip")
+        .append("circle")
+        .attr("cx", width / 2)
+        .attr("cy", height / 2)
+        .attr("r", 17);
+
+      svg
+        .append("g")
+        .attr("clip-path", "url(#btn-clip)")
+        .attr("filter", "url(#btn-blur)")
+        .selectAll("circle.node-blur")
+        .data(nodes.slice(1))
+        .join("circle")
+        .attr("class", "node-blur")
+        .attr("r", (d) => d.radius)
+        .attr("opacity", 1)
+        .attr("fill", (d) => getColor(d.type[0]));
+
+      const isDark = () => document.documentElement.dataset.theme === "dark";
+      const themeIcon = () => (isDark() ? "☀️" : "🌘");
+
+      const toggleTheme = () => {
+        document.documentElement.dataset.theme = isDark() ? "light" : "dark";
+        btn.select("text").text(themeIcon());
+        btn.attr(
+          "aria-label",
+          isDark() ? "Switch to light mode" : "Switch to dark mode",
+        );
+      };
+
+      const btn = svg
+        .append("g")
+        .attr("transform", `translate(${width / 2}, ${height / 2})`)
+        .attr("cursor", "pointer")
+        .attr("class", "center-btn")
+        .attr("role", "button")
+        .attr("tabindex", "0")
+        .attr(
+          "aria-label",
+          isDark() ? "Switch to light mode" : "Switch to dark mode",
+        )
+        .on("click", toggleTheme)
+        .on("keydown", (event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            toggleTheme();
+          }
+        });
+
+      btn
+        .append("circle")
+        .attr("r", 18)
+        .attr("fill", "transparent")
+        .attr("stroke", "var(--site-text)")
+        .attr("stroke-width", 1.5);
+
+      btn
+        .append("text")
+        .attr("text-anchor", "middle")
+        .attr("dominant-baseline", "central")
+        .attr("font-size", "16px")
+        .attr("pointer-events", "none")
+        .text(themeIcon());
 
       svg.on("mousemove", function (event) {
         const p1 = d3.pointer(event, this);
@@ -126,6 +205,7 @@ const Header = (props) => {
       <div id="viz">
         <svg ref={svgRef}></svg>
       </div>
+
       <nav role="navigation">
         <ul>
           <li id="nav-home" className={activeLink === "home" ? "active" : ""}>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -3,7 +3,13 @@ import { Html, Head, Main, NextScript } from "next/document";
 export default function Document() {
   return (
     <Html lang="en">
-      <Head />
+      <Head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){document.documentElement.dataset.theme=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';})();`,
+          }}
+        />
+      </Head>
       <body>
         <Main />
         <NextScript />

--- a/public/rss.xml
+++ b/public/rss.xml
@@ -9,9 +9,9 @@
             <link>https://aadittambe.com</link>
         </image>
         <generator>RSS for Node</generator>
-        <lastBuildDate>Thu, 19 Feb 2026 04:35:11 GMT</lastBuildDate>
+        <lastBuildDate>Tue, 17 Mar 2026 19:03:38 GMT</lastBuildDate>
         <atom:link href="https://aadittambe.com/rss.xml" rel="self" type="application/rss+xml"/>
-        <pubDate>Thu, 19 Feb 2026 04:35:11 GMT</pubDate>
+        <pubDate>Tue, 17 Mar 2026 19:03:38 GMT</pubDate>
         <copyright><![CDATA[All rights reserved 2026]]></copyright>
         <item>
             <title><![CDATA[Optimizing Next.js with Flat JSON Files]]></title>

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -1,5 +1,9 @@
 @use "./globals" as *;
 
+.center-btn:focus {
+  outline: none;
+}
+
 header {
   max-width: calc($xs + 18px);
   margin: 0px auto;

--- a/styles/_theme.scss
+++ b/styles/_theme.scss
@@ -6,18 +6,32 @@
 
   --site-yellow: #8b80d6;
   --site-text-on-yellow: #eaeaf0;
+
+  --node-development: #c4a4f8; /* Dracula purple  ~270° */
+  --node-graphics: #f8be70; /* Dracula orange   ~30°  */
+  --node-app: #98eab0;      /* Dracula green    ~140° */
+  --node-docs: #f0f080;     /* Dracula yellow   ~60°  */
+  --node-data: #88e0f8;     /* Dracula cyan     ~190° */
+  --node-reporting: #f8a0a0; /* Dracula red      ~0°   */
+  --node-default: #f0a0d8;  /* Dracula pink     ~310° */
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --site-background: #282a36;
-    --site-text: #f8f8f2;
-    --site-background-alt: #343746; /* pre */
-    --site-text-alt: #cfd3f0;
+[data-theme="dark"] {
+  --site-background: #282a36;
+  --site-text: #f8f8f2;
+  --site-background-alt: #343746; /* pre */
+  --site-text-alt: #cfd3f0;
 
-    --site-yellow: #8b80d6;
-    --site-text-on-yellow: #eaeaf0;
-  }
+  --site-yellow: #8b80d6;
+  --site-text-on-yellow: #eaeaf0;
+
+  --node-development: #bd93f9; /* Dracula purple */
+  --node-graphics: #ffb86c; /* Dracula orange */
+  --node-app: #50fa7b; /* Dracula green */
+  --node-docs: #f1fa8c; /* Dracula yellow */
+  --node-data: #8be9fd; /* Dracula cyan */
+  --node-reporting: #ff5555; /* Dracula red */
+  --node-default: #ff79c6; /* Dracula pink */
 }
 
 $site-background: var(--site-background);


### PR DESCRIPTION
## Summary

- Adds a system-aware light/dark mode that initializes before first paint (no flash) and a toggle button embedded in the D3 force-graph visualization
- Replaces `prefers-color-scheme` media query with `[data-theme]` attribute on `<html>`, giving manual override control
- Refactors `Header.js`: removes `useState` for active link, extracts nav links to a constant, cleans up the D3 simulation setup (clears on re-render, adds mouseleave reset, fixes blur/clip-path button effect)
- Adds per-theme CSS custom properties for node colors so the visualization adapts to light and dark themes

## Test plan

- [x] Visit site with system set to dark mode — background should be dark on first load with no flash
- [x] Visit site with system set to light mode — background should be light on first load with no flash
- [x] Click the toggle button in the D3 viz — theme should switch and button icon should update
- [x] Press Enter/Space on the toggle button — theme should toggle (keyboard accessibility)
- [x] Navigate between pages — active nav link highlights correctly
- [x] Navigate to a blog post — Blog nav item appears and is highlighted
- [x] Hover over the D3 visualization — nodes scatter; on mouseleave they return to center

🤖 Generated with [Claude Code](https://claude.com/claude-code)