### PR TITLE
Persist dark mode preference across page refreshes

### DIFF
--- a/components/D3Viz.js
+++ b/components/D3Viz.js
@@ -104,7 +104,9 @@ const D3Viz = () => {
         );
 
       function toggleTheme() {
-        document.documentElement.dataset.theme = isDark() ? "light" : "dark";
+        const newTheme = isDark() ? "light" : "dark";
+        document.documentElement.dataset.theme = newTheme;
+        localStorage.setItem("theme", newTheme);
         btn.select("text").text(themeIcon());
         btn.attr(
           "aria-label",

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -6,7 +6,7 @@ export default function Document() {
       <Head>
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){document.documentElement.dataset.theme=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';})();`,
+            __html: `(function(){var saved=localStorage.getItem('theme');document.documentElement.dataset.theme=saved?saved:(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');})();`,
           }}
         />
       </Head>


### PR DESCRIPTION
## Summary
- Saves theme selection to `localStorage` on toggle
- Reads `localStorage` on page init before falling back to `prefers-color-scheme`
- Fixes dark mode resetting to system preference on refresh

## Test plan
- [x] Toggle to dark mode, refresh — should stay dark
- [x] Toggle to light mode on a dark-preference system, refresh — should stay light
- [x] Clear localStorage, refresh — should respect system `prefers-color-scheme`

🤖 Generated with [Claude Code](https://claude.com/claude-code)