### PR TITLE
Fix horizontal overflow at 673-712px

### DIFF
--- a/styles/_blog.scss
+++ b/styles/_blog.scss
@@ -2,7 +2,7 @@
 
 .blog {
   &.container {
-    max-width: $xs;
+    max-width: calc($xs + 36px);
     margin: auto;
   }
   padding-left: 18px;
@@ -43,7 +43,7 @@
 }
 
 .post {
-  max-width: $xs;
+  max-width: calc($xs + 36px);
   margin: auto;
   padding-left: 18px;
   padding-right: 18px;

--- a/styles/_contact.scss
+++ b/styles/_contact.scss
@@ -5,7 +5,7 @@
   padding-right: 18px;
 
   &.container {
-    max-width: $xs;
+    max-width: calc($xs + 36px);
     margin: auto;
   }
 

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -1,7 +1,7 @@
 @use "./globals" as *;
 
 .site-header {
-  max-width: calc($xs + 18px);
+  max-width: calc($xs + 36px);
   margin: 0px auto;
   width: 100%;
   display: flex;
@@ -40,6 +40,7 @@
   }
   ul {
     margin: 0px;
+    margin-left: -6px;
     padding: 0px;
     list-style-type: none;
     display: flex;

--- a/styles/_home.scss
+++ b/styles/_home.scss
@@ -6,7 +6,7 @@
   flex-direction: column;
 
   .home {
-    max-width: $xs;
+    max-width: calc($xs + 36px);
     margin: 0px auto;
     padding-left: 18px;
     padding-right: 18px;

--- a/styles/_resume.scss
+++ b/styles/_resume.scss
@@ -1,7 +1,7 @@
 @use "./globals" as *;
 
 .resume {
-  max-width: $xs;
+  max-width: calc($xs + 36px);
   margin: auto;
   padding-left: 18px;
   padding-right: 18px;

--- a/styles/base.scss
+++ b/styles/base.scss
@@ -17,6 +17,12 @@
   justify-content: space-between;
 }
 
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 * {
   transition:
     background-color 0.25s ease,


### PR DESCRIPTION
## Summary
- Add global `box-sizing: border-box` reset to prevent padding from causing overflow
- Update `max-width` values across content sections to account for border-box model
- Use negative margin on nav `ul` to keep nav text visually aligned with page content

## Test plan
- [x] Resize browser between 673-712px and verify no horizontal scrollbar
- [x] Verify nav text ("Home", etc.) aligns with body content below
- [x] Check all pages (home, blog, resume, contact, projects) at various widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)