### PR TITLE
Add GitHub Actions workflow for SFTP deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Deploy via SFTP
+        uses: wlixcc/SFTP-Deploy-Action@v1.2.4
+        with:
+          server: "${{ secrets.FTP_HOST }}"
+          username: "${{ secrets.FTP_USERNAME }}"
+          password: "${{ secrets.FTP_PASSWORD }}"
+          port: "22"
+          local_path: "./out/*"
+          remote_path: "/public_html/"
+          sftp_only: true
+          delete_remote_files: true


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that builds the Next.js site and deploys the static export to the FTP server via SFTP
- Mirrors what `npm run deploy` does locally
- Triggers on push to `main` and manual dispatch

## Setup
Requires these repository secrets:
- `FTP_HOST`
- `FTP_USERNAME`
- `FTP_PASSWORD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)